### PR TITLE
0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,28 @@ This tool converts [TIL](https://simonwillison.net/2022/Nov/6/what-to-blog-about
 
 ## Setup
 
-1. Install [Bun](https://bun.sh/) v1.0.1 (or higher). Note: as of this version, [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) is required if running in Windows.
-2. Install dependencies with:
+### Install Bun
+
+Install [Bun](https://bun.sh/) v1.0.1 (or higher).
+
+Notes for Windows 11 users:
+
+- As of writing, [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) is required if running in Windows.
+- WSL requires that [Virtual Machine Platform](https://support.microsoft.com/en-us/windows/enable-virtualization-on-windows-11-pcs-c5578302-6e43-4b4b-a449-8ced115f58e1) is enabled.
+
+#### Install unzip
+
+Bun requires a tool called unzip.
+
+Run the following command in WSL (or alternative installation method):
+
+```bash
+sudo apt-get install unzip
+```
+
+### Install project dependencies
+
+Navigate to the application's directory and run the following command:
 
 ```bash
 bun install

--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ til-to-html [-h | --help] [-v | --version] [-o | --output directory] filename | 
 
 ### Command Line Arguments
 
-| Argument          | Description                                                                                        |
-| ----------------- | -------------------------------------------------------------------------------------------------- |
-| `--version`, `-v` | Display version information.                                                                       |
-| `--help`, `-h`    | Display usage message.                                                                             |
-| `--output`, `-o`  | Set custom output directory. If ommitted, files will be output to a folder named `til`. (optional) |
+| Argument          | Description                                                                                       |
+| ----------------- | ------------------------------------------------------------------------------------------------- |
+| `-v`, `--version` | Display version information.                                                                      |
+| `-h`, `--help`    | Display usage message.                                                                            |
+| `-o`, `--output`  | Set custom output directory. If omitted, files will be output to a folder named `til`. (optional) |
 
 ### Examples
 

--- a/src/mdToHtml.ts
+++ b/src/mdToHtml.ts
@@ -4,6 +4,8 @@ import parseParagraph from "@/parseParagraph";
 export default function mdToHtml(md: string, fname: string) {
   let bodyHtml = "";
   let paragraphs = md.split(/\r?\n/);
+  let title = fname;
+
   const hasTitle =
     paragraphs[0].length > 0 && paragraphs[1] === "" && paragraphs[2] === "";
 
@@ -18,6 +20,7 @@ export default function mdToHtml(md: string, fname: string) {
 
     if (firstLine && hasTitle) {
       lineHtml += `<h1>${parsedParagraph}</h1>`;
+      title = parsedParagraph; // Set <title> tag
     } else {
       lineHtml += `<p>${parsedParagraph}</p>`;
     }
@@ -30,7 +33,7 @@ export default function mdToHtml(md: string, fname: string) {
   html += `<html lang="en">\n`;
   html += `<head>\n`;
   html += `\t<meta charset="utf-8">\n`;
-  html += `\t<title>${fname}</title>\n`;
+  html += `\t<title>${title}</title>\n`;
   html += `\t<meta name="viewport" content="width=device-width, initial-scale=1">\n`;
   html += `</head>\n`;
   html += `<body>\n`;

--- a/src/options/help.ts
+++ b/src/options/help.ts
@@ -3,9 +3,21 @@ import getPackageInfo from "@/helpers/getPackageInfo";
 // Prints usage message
 export default async function help() {
   const packageInfo = await getPackageInfo();
-
   const tool = packageInfo.name;
-  console.log(
-    `${tool} [-h | --help] [-v | --version] [-o | --output output] filename | directory`
-  );
+
+  let message = "";
+  message += `Usage: ${tool} [OPTIONS] [ARGUMENT]\n\n`;
+  message += `Description: ${tool} is a tool that converts TIL Markdown posts into static HTML pages.\n\n`;
+
+  message += `Options:\n`;
+  message += `\t-h, --help\t\tDisplay usage.\n`;
+  message += `\t-v, --version\t\tDisplay version.\n`;
+  message += `\t-o, --output DIRECTORY\tIndicate a custom output directory.\n`;
+  message += `\n`;
+
+  message += `Arguments:\n`;
+  message += `\tTARGET\t\t\tEither a single input text file or folder to convert.`;
+  message += `\n\n`;
+
+  console.log(message);
 }


### PR DESCRIPTION
Fixes #2, Fixes #3  - Corrected typo.
Fixes #4 - Made help message much more verbose and human readable.
Fixes #5 - `<title>` tag now correctly populated.
Fixes #6 - Added additional instructions and caveats for installing bun on Windows.