### PR TITLE
Add initial support for Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # til-to-html
 
-This tool converts [TIL](https://simonwillison.net/2022/Nov/6/what-to-blog-about/) posts written in [Markdown](https://www.markdownguide.org/) into static HTML pages.
+This tool converts [TIL](https://simonwillison.net/2022/Nov/6/what-to-blog-about/) posts written in [Markdown](https://www.markdownguide.org/) (.txt, .md) into static HTML pages.
 
 ## Setup
 

--- a/examples/dir/markdown1.md
+++ b/examples/dir/markdown1.md
@@ -1,8 +1,8 @@
 This is a Heading 2 markdown test file 1
 
 
- First Heading 2 ## Testing out 
-  --
+First Heading 2 ## Testing out 
+--
 A TIL—Today I Learned—is the most liberating form of content I know of.
 
 Did you just learn how to do something? Write about that.

--- a/examples/dir/markdown1.md
+++ b/examples/dir/markdown1.md
@@ -1,0 +1,20 @@
+This is a Heading 2 markdown test file 1
+
+
+ First Heading 2 ## Testing out 
+  --
+A TIL—Today I Learned—is the most liberating form of content I know of.
+
+Did you just learn how to do something? Write about that.
+
+Call it a TIL—that way you’re not promising anyone a revelation or an in-depth tutorial. You’re saying “I just figured this out: here are my notes, you may find them useful too”.
+
+I also like the humility of this kind of content. Part of the reason I publish them is to emphasize that even with 25 years of professional experience you should still celebrate learning even the most basic of things.
+
+Second Heading 2
+  -----------------------------------------
+I learned the “interact” command in pdb the other day! [Here’s my TIL](https://til.simonwillison.net/python/pdb-interact).
+
+I started publishing TILs [in April 2020](https://simonwillison.net/2020/Apr/20/self-rewriting-readme/). I’m up to 346 now, and most of them took less than 10 minutes to write. It’s such a great format for quick and satisfying online writing.
+
+My collection lives at https://til.simonwillison.net/—which publishes content from my [simonw/til](https://github.com/simonw/til) GitHub repository.

--- a/examples/markdown.md
+++ b/examples/markdown.md
@@ -1,0 +1,17 @@
+markdown-to-html test
+
+
+A tool to convert [TIL](https://simonwillison.net/2022/Nov/6/what-to-blog-about/) posts written in [Markdown](https://www.markdownguide.org/) into **static HTML pages**.
+
+## Usage for Flags - Heading 2
+Run **til-to-html -h** for additional help.
+
+Run **til-to-html -v** for version information.
+
+Usage for Paths - Heading 2
+-
+Run **til-to-html ./examples/til.txt** to generate a single webpage.
+
+Run **til-to-html ./examples/dir** to generate multiple webpages from a folder.
+
+Refer to the [til-to-html repository](https://github.com/paulkim26/til-to-html) for additional information.

--- a/examples/markdown.md
+++ b/examples/markdown.md
@@ -8,8 +8,7 @@ Run **til-to-html -h** for additional help.
 
 Run **til-to-html -v** for version information.
 
-Usage for Paths - Heading 2
--
+  ##       Usage for Paths - Heading 2
 Run **til-to-html ./examples/til.txt** to generate a single webpage.
 
 Run **til-to-html ./examples/dir** to generate multiple webpages from a folder.

--- a/src/parse-markdown/index.ts
+++ b/src/parse-markdown/index.ts
@@ -10,8 +10,8 @@ export default function parseMarkdown(md: string, fname: string) {
     paragraphs[0].length > 0 && paragraphs[1] === "" && paragraphs[2] === "";
 
   // Check for alternative Heading Two syntax
-  for (let i = 0; i < paragraphs.length; i++) {
-    if (i < paragraphs.length - 1 && paragraphs[i + 1].match(/^( {0,3}-+\s*)$/) != null) {
+  for (let i = 0; i < (paragraphs.length - 1); i++) {
+    if (paragraphs[i + 1].match(/^( {0,3}-+\s*)$/) !== null) {
       paragraphs[i] = `${paragraphs[i]}\n${paragraphs[i + 1]}`;
       paragraphs[i + 1] = "";
     }
@@ -31,7 +31,7 @@ export default function parseMarkdown(md: string, fname: string) {
       title = parsedParagraph; // Set <title> tag
     } else {
       if (parsedParagraph.startsWith("<h2>") && parsedParagraph.endsWith("</h2>")) {
-        lineHtml += `${parsedParagraph}`;
+        lineHtml += parsedParagraph;
       } else {
         lineHtml += `<p>${parsedParagraph}</p>`;
       }

--- a/src/parse-markdown/index.ts
+++ b/src/parse-markdown/index.ts
@@ -11,7 +11,7 @@ export default function parseMarkdown(md: string, fname: string) {
 
   // Check for alternative Heading Two syntax
   for (let i = 1; i < paragraphs.length; i++) {
-    if (paragraphs[i].match(/^( {0,3}-+\s*)/) != null) {
+    if (paragraphs[i].match(/^( {0,3}-+\s*)$/) != null) {
       paragraphs[i] = "";
       paragraphs[i - 1] = `<h2>${paragraphs[i - 1]}</h2>`;
     }

--- a/src/parse-markdown/index.ts
+++ b/src/parse-markdown/index.ts
@@ -10,10 +10,10 @@ export default function parseMarkdown(md: string, fname: string) {
     paragraphs[0].length > 0 && paragraphs[1] === "" && paragraphs[2] === "";
 
   // Check for alternative Heading Two syntax
-  for (let i = 1; i < paragraphs.length; i++) {
-    if (paragraphs[i].match(/^( {0,3}-+\s*)$/) != null) {
-      paragraphs[i] = "";
-      paragraphs[i - 1] = `<h2>${paragraphs[i - 1]}</h2>`;
+  for (let i = 0; i < paragraphs.length; i++) {
+    if (i < paragraphs.length - 1 && paragraphs[i + 1].match(/^( {0,3}-+\s*)$/) != null) {
+      paragraphs[i] = `${paragraphs[i]}\n${paragraphs[i + 1]}`;
+      paragraphs[i + 1] = "";
     }
   }
 

--- a/src/parse-markdown/index.ts
+++ b/src/parse-markdown/index.ts
@@ -9,6 +9,14 @@ export default function parseMarkdown(md: string, fname: string) {
   const hasTitle =
     paragraphs[0].length > 0 && paragraphs[1] === "" && paragraphs[2] === "";
 
+  // Check for alternative Heading Two syntax
+  for (let i = 1; i < paragraphs.length; i++) {
+    if (paragraphs[i].match(/^( {0,3}-+\s*)/) != null) {
+      paragraphs[i] = "";
+      paragraphs[i - 1] = `<h2>${paragraphs[i - 1]}</h2>`;
+    }
+  }
+
   // Clear empty paragraphs
   paragraphs = paragraphs.filter((paragraph) => paragraph !== "");
 
@@ -22,7 +30,11 @@ export default function parseMarkdown(md: string, fname: string) {
       lineHtml += `<h1>${parsedParagraph}</h1>`;
       title = parsedParagraph; // Set <title> tag
     } else {
-      lineHtml += `<p>${parsedParagraph}</p>`;
+      if (parsedParagraph.startsWith("<h2>") && parsedParagraph.endsWith("</h2>")) {
+        lineHtml += `${parsedParagraph}`;
+      } else {
+        lineHtml += `<p>${parsedParagraph}</p>`;
+      }
     }
 
     bodyHtml += `${lineHtml}\n`;

--- a/src/parse-markdown/parseBlock.ts
+++ b/src/parse-markdown/parseBlock.ts
@@ -1,6 +1,7 @@
 import parseLink from "@/parse-markdown/parseLink";
 import parseBold from "@/parse-markdown/parseBold";
 import parseItalics from "@/parse-markdown/parseItalics";
+import parseHeadingTwo from "./parseHeadingTwo";
 
 // Parse text within paragraph tag
 export default function parseBlock(text: string) {
@@ -9,6 +10,7 @@ export default function parseBlock(text: string) {
   html = parseLink(html);
   html = parseBold(html);
   html = parseItalics(html);
+  html = parseHeadingTwo(html);
 
   return html;
 }

--- a/src/parse-markdown/parseBlock.ts
+++ b/src/parse-markdown/parseBlock.ts
@@ -7,10 +7,10 @@ import parseHeadingTwo from "./parseHeadingTwo";
 export default function parseBlock(text: string) {
   let html = text;
 
+  html = parseHeadingTwo(html);
   html = parseLink(html);
   html = parseBold(html);
   html = parseItalics(html);
-  html = parseHeadingTwo(html);
 
   return html;
 }

--- a/src/parse-markdown/parseHeadingTwo.ts
+++ b/src/parse-markdown/parseHeadingTwo.ts
@@ -1,0 +1,11 @@
+export default function parseHeadingTwo(text: string) {
+  let html = text;
+
+  const headingTwoPattern = /^( {0,3}##\s+.*)/;
+  html = html.replace(headingTwoPattern, (match, headingTwoText) => {
+    let headingTwo = headingTwoText.split("##")[1].trim();
+    return `<h2>${headingTwo}</h2>`;
+  });
+
+  return html;
+}

--- a/src/parse-markdown/parseHeadingTwo.ts
+++ b/src/parse-markdown/parseHeadingTwo.ts
@@ -3,8 +3,14 @@ export default function parseHeadingTwo(text: string) {
 
   const headingTwoPattern = /^( {0,3}##\s+.*)/;
   html = html.replace(headingTwoPattern, (match, headingTwoText) => {
-    let headingTwo = headingTwoText.split(/##/).slice(1).join('##').trim();
+    let headingTwo = headingTwoText.split(/##/).slice(1).join("##").trim();
     return `<h2>${headingTwo}</h2>`;
+  });
+
+  const headingTwoPattern2 = /^(.*\n {0,3}-+\s*)/;
+  html = html.replace(headingTwoPattern2, (match, headingTwoText) => {
+    let altHeadingTwo = headingTwoText.split(/\n/)[0].trim();
+    return `<h2>${altHeadingTwo}</h2>`;
   });
 
   return html;

--- a/src/parse-markdown/parseHeadingTwo.ts
+++ b/src/parse-markdown/parseHeadingTwo.ts
@@ -3,14 +3,14 @@ export default function parseHeadingTwo(text: string) {
 
   const headingTwoPattern = /^( {0,3}##\s+.*)/;
   html = html.replace(headingTwoPattern, (match, headingTwoText) => {
-    let headingTwo = headingTwoText.split(/##/).slice(1).join("##").trim();
+    const headingTwo = headingTwoText.split(/##/).slice(1).join("##").trim();
     return `<h2>${headingTwo}</h2>`;
   });
 
   const headingTwoPattern2 = /^(.*\n {0,3}-+\s*)/;
   html = html.replace(headingTwoPattern2, (match, headingTwoText) => {
-    let altHeadingTwo = headingTwoText.split(/\n/)[0].trim();
-    return `<h2>${altHeadingTwo}</h2>`;
+    const headingTwo = headingTwoText.split(/\n/)[0].trim();
+    return `<h2>${headingTwo}</h2>`;
   });
 
   return html;

--- a/src/parse-markdown/parseHeadingTwo.ts
+++ b/src/parse-markdown/parseHeadingTwo.ts
@@ -3,7 +3,7 @@ export default function parseHeadingTwo(text: string) {
 
   const headingTwoPattern = /^( {0,3}##\s+.*)/;
   html = html.replace(headingTwoPattern, (match, headingTwoText) => {
-    let headingTwo = headingTwoText.split("##")[1].trim();
+    let headingTwo = headingTwoText.split(/##/).slice(1).join('##').trim();
     return `<h2>${headingTwo}</h2>`;
   });
 

--- a/src/parseArguments.ts
+++ b/src/parseArguments.ts
@@ -46,14 +46,14 @@ export default async function parseArguments(args: string[]) {
 
   if (foundTarget) {
     const filesToProcess = [];
-    const isFolder = !target.endsWith(".txt");
+    const isFolder = !(target.endsWith(".txt") || target.endsWith(".md"));
 
     console.log(`Reading files...`);
 
     if (isFolder) {
       // Parse folder of text files
       const dir = target;
-      let files = readdirSync(dir).filter((file) => file.endsWith(".txt"));
+      let files = readdirSync(dir).filter((file) => file.endsWith(".txt") || file.endsWith(".md"));
       files = files.map((file) => `${dir}/${file}`);
 
       files.forEach((file) => filesToProcess.push(file));


### PR DESCRIPTION
Resolves #9 

- Updated `parseArguments.ts` to also check if input path ends in `.md` 
- Created `parseHeadingTwo.ts` file inside `./src/parse-markdown` folder and added function to replace Heading 2 markdown syntax with appropriate `<h2>...</h2>` HTML tag
    - Within `./src/parse-markdown/index.ts`, the input text is being split into singular lines, but since the alternative Heading 2 syntax is based on two lines (alternate syntax is having a form of  `---` on the line after the desired Heading 2 line), I needed to join back the lines that matched this type of syntax, and then push it to the `parseBlock(paragraph)` function
- Updated `parseBlock.ts` to run `parseHeadingTwo` function within `parseBlock` function
- Added `.md` sample files inside ./examples folder
- Updated README to include file extensions that are supported
